### PR TITLE
Use `main` property for right npm module resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "tiny-cookie",
   "description": "A tiny cookie manipulation plugin",
+  "main": "tiny-cookie.js",
   "version": "0.5.3",
   "author": {
     "name": "Alex Chao",


### PR DESCRIPTION
Otherwise `Error: Cannot find module 'tiny-cookie' from %my_dir%` when try to `var cookie = require('tiny-cookie');` with `grunt-browserify`.