### PR TITLE
Add partitioned to type def

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -12,4 +12,5 @@ export interface CookieOptions {
   "max-age"?: number;
   secure?: boolean;
   samesite?: string;
+  partitioned?: boolean;
 }


### PR DESCRIPTION
Hi,

Partitioned cookies are becoming a thing (https://github.com/privacycg/CHIPS). tiny-cookie already supports them (nice work on that implementation) but it's just missing it from the type def. this PR adds it in.